### PR TITLE
Add non-x86_64 support, fix build issues and Docker warnings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+.gitignore
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
+#syntax=docker/dockerfile:1.18.0
+# builder https://docs.docker.com/build/buildkit/dockerfile-release-notes/
 FROM golang:1.25-alpine3.22 AS builder
 
 RUN mkdir /app
 ADD . /app
 WORKDIR /app
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o seonaut cmd/server/main.go
+# RUN https://medium.com/@marcin.niemira/optimise-docker-build-for-go-c03d6eb8b4b
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux \
+    go build -o seonaut cmd/server/main.go
 
 FROM node:18-alpine3.18 AS front
 WORKDIR /home/node
 COPY --from=builder /app ./app/
-RUN npm install --save-exact esbuild && ./node_modules/esbuild/bin/esbuild ./app/web/css/style.css \
+# RUN https://docs.docker.com/build/cache/optimize/#use-cache-mounts
+RUN --mount=type=cache,target=/root/.npm \
+    npm install --save-exact esbuild && \
+    ./node_modules/esbuild/bin/esbuild ./app/web/css/style.css \
 	--bundle \
 	--minify \
 	--outdir=./app/web/static \
@@ -20,8 +29,15 @@ RUN npm install --save-exact esbuild && ./node_modules/esbuild/bin/esbuild ./app
 FROM alpine:latest AS production
 COPY --from=front /home/node/app /app/
 
-ENV WAIT_VERSION 2.9.0
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /bin/wait
-RUN chmod +x /bin/wait
+ARG TARGETARCH
+# https://medium.com/@tonistiigi/new-dockerfile-capabilities-in-v1-7-0-be6873650741
+# WAIT_ARCH argument string substitution requires Dockerfile 1.7.0 or newer syntax.
+ARG WAIT_ARCH=${TARGETARCH/amd64/_x64_64}
+ARG WAIT_ARCH=${WAIT_ARCH/arm64/_aarch64}
+ARG WAIT_ARCH=${WAIT_ARCH/arm_v7/_armv7}
+ARG WAIT_ARCH=${WAIT_ARCH:-}
+# WAIT_VERSION https://github.com/ufoscout/docker-compose-wait/releases
+ARG WAIT_VERSION=2.12.1
+ADD --chmod=755 https://github.com/ufoscout/docker-compose-wait/releases/download/${WAIT_VERSION}/wait${WAIT_ARCH} /bin/wait
 
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Run the main server
 run:
-	go run -race cmd/server/main.go -c config.local 
+	go run -race cmd/server/main.go -c config.local
 .PHONY: run
 
 # Run tests
@@ -15,8 +15,13 @@ vet:
 
 # Run docker compose
 docker:
-	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 .PHONY: docker
+
+# Clean Docker builder cache
+clean:
+	docker builder prune -f
+.PHONY: clean
 
 # Watch frontend files to run esbuild on any change
 watch:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.8"
-
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: "SEOnaut-db"
     environment:
       - MYSQL_ROOT_PASSWORD=root
@@ -22,7 +20,7 @@ services:
     command: sh -c "/bin/wait && /app/seonaut"
     environment:
       - WAIT_HOSTS=db:3306
-      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_TIMEOUT=300
       - WAIT_SLEEP_INTERVAL=30
       - WAIT_HOST_CONNECT_TIMEOUT=30
     networks:

--- a/translations/translation.en.yaml
+++ b/translations/translation.en.yaml
@@ -275,7 +275,7 @@ INTERNAL_TAB_INFO: Internal links are the links found in this URL's HTML code th
 EXTERNAL_TAB: External links
 EXTERNAL_TAB_INFO: External links are the links found in this URL's HTML code pointing to other websites.
 REDIRECTIONS_TAB: Redirections
-REDIRECTIONS_TAB_INFO: Redirections are the URLs from this website that are redirected to this URL. 
+REDIRECTIONS_TAB_INFO: Redirections are the URLs from this website that are redirected to this URL.
 IMAGES_TAB: Images
 IMAGES_TAB_INFO: Images that are found in this URL's HTML code. Note that images shown using CSS are not included here.
 AUDIOS_TAB: Audios
@@ -406,15 +406,15 @@ ERROR_DUPLICATED_TITLE_DESC: The title tag is considered one of the most importa
 ERROR_LONG_TITLE: Pages with long title
 ERROR_LONG_TITLE_DESC: Long titles won't affect your on-page SEO, but they are usually cut off on search results and tend to get fewer clicks.
 
-ERROR_SHORT_TITLE: Pages short title
+ERROR_SHORT_TITLE: Pages with short title
 ERROR_SHORT_TITLE_DESC: These pages have titles that are too short. Search engines will be happier if you provide longer titles.
-  
+
 ERROR_EMPTY_TITLE: Pages with missing title
 ERROR_EMPTY_TITLE_DESC: Page titles help search engines understand what a page is about and are often shown in search results. Without a title, your page may rank lower, get overlooked by users, and appear unprofessional or incomplete.
 
 ERROR_EMPTY_DESCRIPTION: Pages with missing meta description
 ERROR_EMPTY_DESCRIPTION_DESC: Page description is not a ranking factor for search engines, but they often use it to show snippets on search results.
-  
+
 ERROR_SHORT_DESCRIPTION: Pages with short meta description
 ERROR_SHORT_DESCRIPTION_DESC: Page description is not a ranking factor for search engines, but they often use it to show snippets on search results.
 
@@ -454,9 +454,9 @@ ERROR_EXTERNAL_WITHOUT_NOFOLLOW_DESC: Follow links will pass SEO authority to ex
 ERROR_CANONICALIZED_NON_CANONICAL: Canonicalized to non canonical
 ERROR_CANONICALIZED_NON_CANONICAL_DESC: Pages canonicalized to a non canonical URL. Canonicalized pages should point to a canonical page, replace the canonical link URL in this pages so they point to a canonical one.
 
-ERROR_NOT_VALID_HEADINGS: Pages with not valid headings order
+ERROR_NOT_VALID_HEADINGS: Pages without valid headings order
 ERROR_NOT_VALID_HEADINGS_DESC: The heading tags in this pages don't follow the correct order. Headings should start with an H1 and follow a clear hierarchy (H2, H3, etc.). Proper structure helps search engines understand your content and improves accessibility for screen readers.
-  
+
 ERROR_HREFLANG_TO_NON_CANONICAL: Hreflang to non canonical page
 ERROR_HREFLANG_TO_NON_CANONICAL_DESC: Hreflang tags tell search engines where to find content in specific languages, linking hreflang tags to non canonical pages confuses search engines.
 


### PR DESCRIPTION
Add ability to build and deploy the Docker image on non-x86_64 hardware, i.e. ARM64 (aarch64). Update several dependencies to newer supported versions. Fix some Docker warnings and build issues in configuration. Minor grammar and white space corrections.