### PR TITLE
Add Dutch (nl) translation

### DIFF
--- a/translations/translation.nl.yaml
+++ b/translations/translation.nl.yaml
@@ -1,0 +1,623 @@
+# =============================================
+# GLOBAL PARAMETERS GUIDE
+# =============================================
+# NOTE: Never translate placeholders like %1% or %2%.
+
+# =============================================
+# COMMON: Reusable UI elements (buttons, pagination, etc.)
+# =============================================
+VIEW_DETAILS: Details bekijken
+DOWNLOAD: Downloaden
+CRAWLED_ON: "Gecrawld op %1%"  # %1% will be replaced with a date
+CRAWLED: gecrawld
+PREV: ← vorige                 # Pagination: link to previous page
+NEXT: volgende →               # Pagination: link to next page
+EMAIL_LABEL: "E-mail:"         # Form label: used in the Sign in and Sign up pages
+PASSWORD_LABEL: "Wachtwoord:"  # Form label: used in the Sign in and Sign up pages
+SAVE: Opslaan
+DELETE: Verwijderen
+CANCEL: Annuleren
+
+# =============================================
+# CONTEXT: Sign in page
+# =============================================
+SIGN_IN: Inloggen op je account
+SIGIN_ERROR: Het e-mailadres of wachtwoord is niet geldig.
+NEW_USER: Nieuw bij SEOnaut?
+NEW_USER_SIGNUP: Registreren
+SIGNIN_MESSAGE: Welkom terug! Log in om gedetailleerde rapporten te bekijken en kansen te ontdekken om de crawlbaarheid van je website te verbeteren en je positie in de zoekresultaten te verhogen.
+
+# =============================================
+# CONTEXT: Sign up page
+# =============================================
+SIGN_UP: Registreren
+CREATE_ACCOUNT: Maak je SEOnaut-account aan
+HAVE_ACCOUNT: Heb je al een account?
+SIGNIN_LINK: Inloggen
+SIGNUP_MESSAGE: Met SEOnaut kun je je site scannen op problemen, oplossingen prioriteren op basis van impact en aanbevelingen krijgen om je online zichtbaarheid te verbeteren. Registreer je om je website te optimaliseren!
+
+# =============================================
+# CONTEXT: Edit user account page
+# =============================================
+EDIT_ACCOUNT: Account bewerken
+CURRENT_PASSWORD: "Huidig wachtwoord:" # Form label
+NEW_PASSWORD: "Nieuw wachtwoord:"      # Form label
+LANGUAGE_LABEL: "Taal:"                # Form label
+CHANGE_PASSWORD: Wachtwoord wijzigen
+DELETE_ACCOUNT_MESSAGE: Als je SEOnaut niet meer wilt gebruiken, kun je je account hier verwijderen.
+DELETE_ACCOUNT_MESSAGE_CONFIRMATION: Er wordt om bevestiging gevraagd voordat je verdergaat.
+THEME_LABEL: "Thema:"
+GENERIC_ERROR: Er is een fout opgetreden. Probeer het opnieuw.
+INVALID_LANG_ERROR: De taal wordt niet ondersteund.
+NEW_PASSWORD_IS_INVALID: Nieuw wachtwoord is niet geldig.
+CURRENT_PASSWORD_INCORRECT: Huidig wachtwoord is onjuist.
+
+# =============================================
+# CONTEXT: Delete user account page
+# =============================================
+DELETE_ACCOUNT: Account verwijderen
+DELETE_ACCOUNT_WARNING: Door je account te verwijderen, neem je ook afscheid van al je projectgegevens en crawlgeschiedenis.
+THIS_IS_PERMANENT: Deze actie is permanent.
+NO_TURNING_BACK: Eenmaal uitgevoerd, kan dit niet meer ongedaan worden gemaakt.
+ARE_YOU_SURE: Weet je zeker dat je wilt doorgaan?
+PROJECT_CRAWLING: Een of meer van je projecten worden gecrawld of verwijderd.
+WAIT_BEFORE_DELETING: Wacht tot het proces is voltooid voordat je je account verwijdert.
+
+# =============================================
+# CONTEXT: Page header (navigation menu)
+# =============================================
+PROJECTS: Projecten
+ACCOUNT: Account
+LOGOUT: Uitloggen
+
+# =============================================
+# CONTEXT: Page footer (additional links)
+# =============================================
+SUPPORT: ❤️ Toon wat liefde
+OFFICIAL_WEBSITE: Website van SEOnaut
+
+# =============================================
+# CONTEXT: Add project page. Contains the form to add new projects.
+#          The same fields are also used in the Edit project page.
+# =============================================
+ADD_PROJECT: Project toevoegen
+URL_LABEL: "URL:"
+URL_LABEL_MESSAGE: Volledige project-URL inclusief http:// of https://
+URL_NOT_VALID: De URL is niet geldig.
+IGNORE_ROBOTS_CHECKBOX: robots.txt negeren
+IGNORE_ROBOTS_HELP: Indien aangevinkt zal de crawler alle beperkingen die in je robots-bestand staan negeren.
+FOLLOW_NOFOLLOW_CHECKBOX: Interne nofollow-links volgen
+FOLLOW_NOFOLLOW_HELP: Indien aangevinkt negeert de crawler het nofollow-attribuut in links en de robots-metatag.
+INCLUDE_NOINDEX_CHECKBOX: Noindex-pagina's opnemen in het rapport
+INCLUDE_NOINDEX_HELP: Indien aangevinkt worden ook pagina's met het noindex-attribuut in het rapport opgenomen.
+CRAWL_SITEMAP_CHECKBOX: Sitemap crawlen
+CRAWL_SITEMAP_HELP: Indien aangevinkt worden ook de URL's in de sitemap.xml gecrawld.
+ALLOW_SUBDOMAINS_CHECKBOX: Subdomeinen toestaan
+ALLOW_SUBDOMAINS_HELP: Indien aangevinkt zal de crawler ook URL's van subdomeinen crawlen.
+CHECK_EXTERNAL_LINKS_CHECKBOX: Externe links controleren
+CHECK_EXTERNAL_LINKS_HELP: Indien aangevinkt zoekt de crawler naar gebroken externe links.
+CREATE_WACZ_CHECKBOX: WACZ-archief aanmaken
+CREATE_WACZ_HELP: Indien aangevinkt wordt er een WACZ-archief aangemaakt dat als exportoptie beschikbaar is.
+USE_AUTH_CHECKBOX: HTTP Basic Authentication gebruiken
+USE_AUTH_HELP: Vink deze optie aan als je site beveiligd is met HTTP Basic Auth.
+CUSTOM_USERAGENT_CHECKBOX: Aangepaste User-Agent
+CUSTOM_USERAGENT_HELP: Stel een aangepaste User-Agent in voor de crawler van SEOnaut bij het ophalen van URL's.
+ENTER_USERAGENT_LABEL: "Vul je aangepaste User-Agent string in:"
+USERAGENT_NOT_VALID: De User-Agent is niet geldig.
+
+# =============================================
+# CONTEXT: Edit project page. Contains the edit project form.
+#          The form uses the same fields as the Add project page.
+# =============================================
+EDIT_PROJECT: Project bewerken
+EDIT_ERROR: Er is een fout opgetreden en het project kon niet worden opgeslagen.
+DELETE_PROJECT: Project verwijderen
+DELETE_PROJECT_MESSAGE: Met deze actie verwijder je het project %1% en alle bijbehorende gegevens. # %1% will be replaced with the project's URL
+DELETE_CANT_BE_UNDONE: Het verwijderen van een project kan enkele minuten duren en kan niet ongedaan worden gemaakt.
+
+# =============================================
+# CONTEXT: Projects page. This is the homepage for logged in users.
+# =============================================
+WELCOME: Welkom bij SEOnaut
+WE_LOVE_CRAWLABLE_WEBSITES: We ❤️ Crawlbare websites
+NO_PROJECTS: Je hebt nog geen project.
+ONE_PROJECT: Je hebt momenteel één project.
+YOU_HAVE_PROJECTS: Je hebt momenteel %1% projecten. # %1% will bre replaced with a number greater than 1
+ADD_FIRST_PROJECT: Voeg je eerste project toe.
+GAIN_INSIGHTS: Verkrijg inzichten over je website.
+DELETING_PROJECT: Project wordt verwijderd.
+DELETING_PLEASE_WAIT: Dit kan enkele minuten duren, even geduld...
+CANT_ACCESS_SITE: De SEOnaut-bot kon je website niet bereiken. Controleer of de URL juist is en niet wordt geblokkeerd door de Robots-instellingen of HTTP Basic Authentication.
+CRAWL_NOW: Nu crawlen
+CRAWLING: Crawlen...
+
+# =============================================
+# CONTEXT: Project dashboard page (charts, crawl details, etc.)
+# =============================================
+DASHBOARD: Dashboard
+ISSUES_MESSAGE: "Er zijn %1% kritieke problemen en %2% waarschuwingen op deze site gedetecteerd." # %1% and %2% will be replaced by numbers
+CRAWL_HISTORY: Crawlgeschiedenis
+ISSUES_HISTORY: Probleemgeschiedenis
+ISSUE_TYPES: Probleemtypen
+CURRENT_CRAWL: Huidige crawl
+CRAWL_DURATION: De crawl duurde %1%  # %1 will be replaced with the time duration of the crawl. Ex: 37s
+FOLLOWING_LINKS: Interne nofollow-links worden gevolgd.
+NOT_FOLLOWING_LINKS: Nofollow-links worden niet gevolgd.
+INCLUDING_NOINDEX: Inclusief noindex-pagina's.
+NOT_INCLUDING_NOINDEX: Exclusief noindex-pagina's.
+CRAWLING_SITEMAP: URL's in sitemap worden gecrawld
+NOT_CRAWLING_SITEMAP: URL's in sitemap worden niet gecrawld
+SITEMAP_BLOCKED: Sitemap geblokkeerd.
+SITEMAP_FOUND: Sitemap gevonden.
+SITEMAP_NOT_FOUND: Sitemap niet gevonden.
+IGNORING_ROBOTS: robots.txt-bestand wordt genegeerd.
+RESPECTING_ROBOTS: robots.txt-bestand wordt gerespecteerd.
+ROBOTS_FOUND: Robots.txt gevonden.
+ROBOTS_NOT_FOUND: Robots.txt niet gevonden.
+LINKS: Links
+CANONICAL_URLS: Canonieke URL's
+IMAGES_ALT: Alt-tekst van afbeeldingen
+HTTPS: HTTPS
+MEDIA_TYPE: Mediatype
+STATUS_CODE: Statuscode
+STATUS_BY_DEPTH: Statuscode per diepte
+NEXT_ACTIONS: Volgende stappen
+EXPLORE_ISSUES: Verken siteproblemen
+EXPLORE_ISSUES_MESSAGE: Ontdek problemen die de prestaties van je website beïnvloeden.
+SITE_ISSUES_LINK: Siteproblemen
+PAGE_DETAILS_LINK: Paginadetails
+ANALYZE_DATA: Onbewerkte gegevens analyseren
+ANALYZE_DATA_MESSAGE: Exporteer je gegevens voor verdere analyse en rapportage.
+ANALYZE_DATA_LINK: Gegevensexport
+URL_CRAWLED: 1 URL gecrawld.        # Singular
+URLS_CRAWLED: "%1% URL's gecrawld." # Plural. %1% will be replaced with a number greater than 1
+CANONICAL: Canoniek
+NON_CANONICAL: Niet-canoniek
+INDEX: Index
+NOINDEX: Noindex
+BLOCKED: Geblokkeerd
+WITH_ALT: Met alt-tekst
+WITHOUT_ALT: Zonder alt-tekst
+CRITICAL: Kritiek
+ALERT: Waarschuwing
+WARNING: Aandachtspunt
+ISSUES: Problemen
+FOLLOW: Follow
+NOFOLLOW: Nofollow
+INTERNAL: Intern
+EXTERNAL: Extern
+TOTAL: Totaal
+SPONSORED: Gesponsord
+UGC: UGC
+SCHEME: Schema
+SAVE_AS_IMAGE: Opslaan als afbeelding
+
+# =============================================
+# CONTEXT: Live crawler page.
+# =============================================
+LIVE_CRAWLING: Live crawlen
+STOP_CRAWLER: Crawler stoppen
+STOPPING_CRAWLER: Crawler wordt gestopt...
+LIVE_CRAWL_JAVASCRIPT_ERROR: Live crawlen is niet beschikbaar in jouw browser. JavaScript-ondersteuning is vereist.
+LIVE_CRAWL_WEBSOCKET_ERROR: Live crawlen is niet beschikbaar in jouw browser. WebSocket-ondersteuning is vereist.
+CONNECTING_TO_SERVER: Verbinden met de server, even geduld...
+CRAWL_COMPLETED: Crawl voltooid. Het rapport wordt aangemaakt, even geduld...
+
+# =============================================
+# CONTEXT: Crawl HTTP Basic auth page. (username and password form for HTTP Basic authentication)
+# =============================================
+HTTP_BASIC_AUTH: HTTP Basic Authentication
+HTTP_BASIC_AUTH_MESSAGE: Dit project gebruikt HTTP Basic Authentication. Je moet de inloggegevens opgeven voordat de crawl start.
+HTTP_BASIC_AUTH_PRIVACY: Inloggegevens worden niet op de server opgeslagen en worden iedere keer opnieuw gevraagd wanneer je dit project wilt crawlen.
+HTTP_BASIC_USERNAME_LABEL: "Gebruikersnaam:"
+HTTP_BASIC_PASSWORD_LABEL: "Wachtwoord:"
+
+# =============================================
+# CONTEXT: Issues index page.
+# =============================================
+NO_ISSUES_MESSAGE: SEOnaut heeft geen problemen op je site gedetecteerd.
+CRITICAL_MESSAGE: "Los deze als eerste op. Ze schaden waarschijnlijk je positie in de zoekresultaten."
+ALERTS_MESSAGE: Door deze op te lossen verbeter je de SEO-prestaties van je site.
+WARNINGS_MESSAGE: Deze problemen zijn afhankelijk van je doelen wellicht niet ernstig, maar het is goed om ze in de gaten te houden.
+PASSED_CHECKS: Geslaagde controles
+PASSED_CHECKS_MESSAGE: Je site heeft de volgende controles met succes doorstaan.
+
+# =============================================
+# CONTEXT: Specific issue page.
+# =============================================
+SITE_ISSUES: Siteproblemen
+VIEW_ISSUES: Problemen bekijken
+URL_AFFECTED: 1 getroffen URL          # Singular
+URLS_AFFECTED: "%1% getroffen URL's"   # Plural. %1% will be replaced with a number greater than 1
+DOWNLOAD_URLS: URL's downloaden
+NO_ISSUES: Alles is in orde
+
+# =============================================
+# CONTEXT: Data export page
+# =============================================
+DATA_EXPORT: Gegevensexport
+EXPORT_SITEMAP: sitemap.xml exporteren
+EXPORT_SITEMAP_MESSAGE: Download een sitemap.xml-bestand met alle canonieke pagina's op je site.
+EXPORT_CVS: Exporteren als CSV
+EXPORT_CVS_MESSAGE: Exporteer alle gecrawlde URL's in CSV-formaat, inclusief alle MIME-types en met aanvullende informatie zoals statuscode en grootte.
+EXPORT_INTERNAL_LINKS: Interne links exporteren
+EXPORT_INTERNAL_LINKS_MESSAGE: Exporteer alle interne links op de website. Inclusief oorsprong, bestemming en ankertekst.
+EXPORT_EXTERNAL_LINKS: Externe links exporteren
+EXPORT_EXTERNAL_LINKS_MESSAGE: Exporteer alle externe links op de website. Inclusief oorsprong, bestemming en ankertekst.
+EXPORT_IMAGES: Afbeeldingen exporteren
+EXPORT_IMAGES_MESSAGE: Exporteer alle afbeeldings-URL's op de website, inclusief oorsprong, afbeeldings-URL's en alt-tekst.
+EXPORT_SCRIPTS: Scripts exporteren
+EXPORT_SCRIPTS_MESSAGE: Exporteer alle script-URL's op de website, inclusief oorsprong en script-URL's.
+EXPORT_STYLES: Stijlen exporteren
+EXPORT_STYLES_MESSAGE: Exporteer alle CSS-stylesheet-URL's op de website, inclusief oorsprong en stijl-URL's.
+EXPORT_IFRAMES: Iframes exporteren
+EXPORT_IFRAMES_MESSAGE: Exporteer alle iframe-URL's op de website, inclusief oorsprong en iframe-URL's.
+EXPORT_AUDIOS: Audio's exporteren
+EXPORT_AUDIOS_MESSAGE: Exporteer alle audio-URL's op de website, inclusief oorsprong en audio-URL's.
+EXPORT_VIDEOS: Video's exporteren
+EXPORT_VIDEOS_MESSAGE: Exporteer alle video-URL's op de website, inclusief oorsprong en video-URL's.
+EXPORT_HREFLANGS: Hreflangs exporteren
+EXPORT_HREFLANGS_MESSAGE: Exporteer alle hreflang-URL's op de website, inclusief oorsprong-URL en taal evenals hreflang-URL en taal.
+EXPORT_ALL: Alle problemen exporteren
+EXPORT_ALL_MESSAGE: Exporteer alle problemen met de getroffen URL's, het probleemtype en de prioriteit.
+EXPORT_WACZ: WACZ-archief exporteren
+EXPORT_WACZ_MESSAGE: Exporteer de gecrawlde gegevens van je project als WACZ-bestand voor archivering of replay.
+
+# =============================================
+# CONTEXT: Resources pages. It includes the tabs for images, links, scripts, etc...
+# =============================================
+DETAILS_TAB: Details
+DETAILS_TAB_INFO: Algemene details over de URL.
+INLINKS_TAB: Inlinks
+INLINKS_TAB_INFO: Inlinks zijn links naar deze URL vanaf andere pagina's op deze website.
+INTERNAL_TAB: Interne links
+INTERNAL_TAB_INFO: Interne links zijn de links in de HTML-code van deze URL die verwijzen naar andere pagina's op deze website.
+EXTERNAL_TAB: Externe links
+EXTERNAL_TAB_INFO: Externe links zijn de links in de HTML-code van deze URL die verwijzen naar andere websites.
+REDIRECTIONS_TAB: Redirects
+REDIRECTIONS_TAB_INFO: Redirects zijn de URL's van deze website die naar deze URL worden doorverwezen.
+IMAGES_TAB: Afbeeldingen
+IMAGES_TAB_INFO: Afbeeldingen die in de HTML-code van deze URL voorkomen. Afbeeldingen die via CSS worden weergegeven, zijn hier niet inbegrepen.
+AUDIOS_TAB: Audio's
+AUDIOS_TAB_INFO: Audiobestanden die in de HTML-code van deze URL voorkomen.
+VIDEOS_TAB: Video's
+VIDEOS_TAB_INFO: Videobestanden die in de HTML-code van deze URL voorkomen.
+IFRAMES_TAB: Iframes
+IFRAMES_TAB_INFO: Iframes die in de HTML-code van deze URL voorkomen.
+SCRIPTS_TAB: Scripts
+SCRIPTS_TAB_INFO: Scriptbestanden die in de code van deze URL voorkomen.
+STYLES_TAB: Stijlen
+STYLES_TAB_INFO: CSS-bestanden die in de HTML-code van deze URL voorkomen.
+CONTENT_TYPE: Content-Type
+TITLE: Titel
+DESCRIPTION: Beschrijving
+H1: H1
+H2: H2
+URL_BLOCKED: De URL wordt geblokkeerd door robots.txt
+URL_NOT_BLOCKED: De URL wordt niet geblokkeerd door robots.txt
+SITEMAP: Sitemap
+URL_IN_SITEMAP: De URL staat in de sitemap
+URL_NOT_IN_SITEMAP: De URL staat niet in de sitemap
+SIZE: Grootte
+ROBOTS: Robots
+REDIRECT_URL: Redirect-URL
+REFRESH: Vernieuwen
+LANGUAGE: Taal
+HREFLANG: Hreflang
+URL: URL
+WORDS: Woorden
+DEPTH: Diepte
+TTFB: TTFB
+WACZ_ARCHIVE: WACZ-archief
+VIEW_ARCHIVE: Gearchiveerde respons bekijken
+OPEN_IN_BROWSER: Openen in browser
+NO_LINKS: Er zijn geen links naar deze pagina.
+NO_REDIRECTS: Er zijn geen redirects naar deze pagina.
+PAGE_HAS_NOFOLLOW: Deze pagina heeft de nofollow-metatag.
+PAGE_LINKS_ARE_NOFOLLOW: Links op deze pagina worden als nofollow beschouwd, ook als ze niet het nofollow-attribuut hebben.
+NO_INTERNAL_LINKS: Er zijn geen interne links op deze pagina.
+BROKEN_LINK: Gebroken link
+NO_EXTERNAL_LINKS: Er zijn geen externe links op deze pagina.
+NO_ALT_ATTRIBUTE: Geen alt-attribuut
+NO_IMAGES: Er zijn geen afbeeldingen op deze pagina.
+NO_IFRAMES: Er zijn geen iframes op deze pagina.
+NO_AUDIOS: Er zijn geen audio's op deze pagina.
+POSTER_LABEL: "Poster:"
+NO_VIDEOS: Er zijn geen video's op deze pagina.
+NO_SCRIPTS: Er zijn geen scripts op deze pagina.
+NO_STYLES: Er zijn geen stijlen op deze pagina.
+
+# =============================================
+# CONTEXT: URL explorer page.
+# =============================================
+URL_EXPLORER: URL Explorer
+SEARCH_TERM_LABEL: "Zoekterm:" # Form label
+OPEN_URL: URL openen
+NO_URLS_FOUND: Geen URL's gevonden
+SEARCH: Zoeken
+
+# =============================================
+# CONTEXT: Archive page.
+# =============================================
+DETAILS: Details
+PAGE_DETAILS: Paginadetails
+HEADERS: Headers
+HEADERS_MESSAGE: Dit blok toont de response headers zoals ontvangen door de crawler.
+BODY: Body
+BODY_MESSAGE: Dit blok toont de response body zoals ontvangen door de crawler.
+
+# =============================================
+# CONTEXT: Replay banner. This banner is shown when browsing an archived page.
+# =============================================
+REPLAY_BANNER: Je bekijkt een gearchiveerde versie van deze pagina
+
+# =============================================
+# CONTEXT: Page titles used in the <title> HTML tags.
+# =============================================
+PROJECTS_VIEW_PAGE_TITLE: Projecten
+ADD_PROJECT_PAGE_TITLE: Project toevoegen
+EDIT_PROJECT_PAGE_TITLE: Project bewerken
+ISSUES_VIEW_PAGE_TITLE: Projectproblemen
+ISSUES_DETAIL_PAGE_TITLE: Probleemdetails
+RESOURCES_VIEW_DETAILS_PAGE_TITLE: Details URL-bron
+RESOURCES_VIEW_INLINKS_PAGE_TITLE: URL-inlinks
+RESOURCES_VIEW_INTERNAL_PAGE_TITLE: Interne links van URL
+RESOURCES_VIEW_EXTERNAL_PAGE_TITLE: Externe links van URL
+RESOURCES_VIEW_REDIRECTIONS_PAGE_TITLE: Redirects van URL
+RESOURCES_VIEW_IMAGES_PAGE_TITLE: Afbeeldingen van URL
+RESOURCES_VIEW_SCRIPTS_PAGE_TITLE: Scripts van URL
+RESOURCES_VIEW_STYLES_PAGE_TITLE: Stijlen van URL
+RESOURCES_VIEW_IFRAMES_PAGE_TITLE: Iframes van URL
+RESOURCES_VIEW_AUDIOS_PAGE_TITLE: Audio's van URL
+RESOURCES_VIEW_VIDEOS_PAGE_TITLE: Video's van URL
+SIGNUP_VIEW_PAGE_TITLE: Registreren
+SIGNIN_VIEW_PAGE_TITLE: Inloggen
+ACCOUNT_VIEW_PAGE_TITLE: Account bewerken
+PROJECT_DASHBOARD_PAGE_TITLE: Projectdashboard
+CRAWL_LIVE_PAGE_TITLE: Project wordt gecrawld
+EXPORT_VIEW_PAGE_TITLE: Exporteren
+CRAWL_AUTH_VIEW_PAGE_TITLE: HTTP Basic Authentication voor project
+EXPLORER_PAGE_TITLE: URL Explorer
+DELETE_ACCOUNT_VIEW_PAGE_TITLE: Account verwijderen
+ARCHIVE_VIEW_PAGE_TITLE: Broncode van archief
+SUPPORT_SEONAUT_VIEW_PAGE_TITLE: SEOnaut-project
+
+# =============================================
+# CONTEXT: Issue types. Name and description of the issue types. Displayed in the issue index page.
+# =============================================
+ERROR_50x: URL's met statuscode 50x
+ERROR_50x_DESC: Dit soort fouten ontstaat meestal door een serverbug of een verkeerde configuratie. De getroffen pagina's laden niet goed en tonen in plaats daarvan een foutmelding, wat je gebruikers afschrikt en zoekmachines irriteert.
+
+ERROR_40x: URL's met statuscode 40x
+ERROR_40x_DESC: Deze pagina's ontbreken en zowel je gebruikers als zoekmachines raken verdwaald. Het kan zoekmachines het signaal geven dat je site niet goed wordt onderhouden. Op den duur kunnen te veel gebroken links de crawl-efficiëntie verminderen en de autoriteit van je site verzwakken.
+
+ERROR_30x: URL's met statuscode 30x
+ERROR_30x_DESC: URL's die redirects veroorzaken sturen gebruikers en zoekmachines naar een andere pagina. Redirects kunnen het laden van pagina's vertragen, gebruikers verwarren en het crawlbudget van zoekmachines verspillen.
+
+ERROR_REDIRECT_CHAIN: URL's die een redirectketen veroorzaken
+ERROR_REDIRECT_CHAIN_DESC: Een redirectketen ontstaat wanneer URL's doorverwijzen naar andere URL's die ook weer doorverwijzen, waardoor een keten van redirects ontstaat. Redirectketens frustreren gebruikers en maken het voor zoekmachines lastiger om je content efficiënt te crawlen en te indexeren.
+
+ERROR_REDIRECT_LOOP: URL's die een redirect-loop veroorzaken
+ERROR_REDIRECT_LOOP_DESC: Een redirect-loop bestaat uit twee URL's die naar elkaar doorverwijzen, waardoor een eindeloze lus van redirects ontstaat. Hierdoor bereiken gebruikers en zoekmachines de bestemming nooit. Dit leidt tot een slechte gebruikerservaring, gebroken navigatie en blokkeert zoekmachines bij het correct crawlen en indexeren van je site.
+
+ERROR_DUPLICATED_TITLE: Pagina's met een dubbele titel
+ERROR_DUPLICATED_TITLE_DESC: De title-tag wordt beschouwd als een van de belangrijkste elementen voor on-page SEO. Als meerdere pagina's dezelfde titel hebben, concurreren ze met elkaar voor een zoekopdracht en raken zoekmachines in de war.
+
+ERROR_LONG_TITLE: Pagina's met een lange titel
+ERROR_LONG_TITLE_DESC: Lange titels beïnvloeden je on-page SEO niet, maar ze worden meestal afgekapt in de zoekresultaten en krijgen daardoor minder kliks.
+
+ERROR_SHORT_TITLE: Pagina's met een korte titel
+ERROR_SHORT_TITLE_DESC: Deze pagina's hebben titels die te kort zijn. Zoekmachines zullen blijer zijn als je langere titels opgeeft.
+
+ERROR_EMPTY_TITLE: Pagina's zonder titel
+ERROR_EMPTY_TITLE_DESC: Paginatitels helpen zoekmachines te begrijpen waar een pagina over gaat en worden vaak in zoekresultaten getoond. Zonder titel kan je pagina lager scoren, door gebruikers worden overgeslagen en onprofessioneel of onvolledig overkomen.
+
+ERROR_EMPTY_DESCRIPTION: Pagina's zonder meta-omschrijving
+ERROR_EMPTY_DESCRIPTION_DESC: De pagina-omschrijving is geen rankingfactor voor zoekmachines, maar wordt vaak gebruikt om snippets in de zoekresultaten te tonen.
+
+ERROR_SHORT_DESCRIPTION: Pagina's met een korte meta-omschrijving
+ERROR_SHORT_DESCRIPTION_DESC: De pagina-omschrijving is geen rankingfactor voor zoekmachines, maar wordt vaak gebruikt om snippets in de zoekresultaten te tonen.
+
+ERROR_LONG_DESCRIPTION: Pagina's met een lange meta-omschrijving
+ERROR_LONG_DESCRIPTION_DESC: Description-tags zijn geen rankingfactor voor zoekmachines, maar goede beschrijvingen zorgen voor accuratere informatie in de zoekresultaten. Lange beschrijvingen worden vaak afgekapt, waardoor ze minder aantrekkelijk zijn voor gebruikers.
+
+ERROR_DUPLICATED_DESCRIPTION: Pagina's met dubbele meta-omschrijving
+ERROR_DUPLICATED_DESCRIPTION_DESC: Het is aanbevolen om voor elke pagina unieke beschrijvingen te gebruiken, zodat zoekmachines je pagina beter begrijpen.
+
+ERROR_LITTLE_CONTENT: Pagina's met weinig content
+ERROR_LITTLE_CONTENT_DESC: Pagina's met weinig content zijn niet erg nuttig voor gebruikers of zoekmachines; overweeg meer content aan je pagina's toe te voegen.
+
+ERROR_IMAGES_NO_ALT: Pagina's met afbeeldingen zonder alt-attribuut
+ERROR_IMAGES_NO_ALT_DESC: Het alt-attribuut van afbeeldingen verbetert de toegankelijkheid van je site en helpt zoekmachines om je afbeeldingen beter te begrijpen.
+
+ERROR_NO_H1: Pagina's zonder H1-kop
+ERROR_NO_H1_DESC: De H1-tag beschrijft het hoofdonderwerp van de pagina; zonder deze tag is het voor zowel gebruikers als zoekmachines lastiger om te begrijpen waarover de pagina gaat.
+
+ERROR_NO_LANG: Pagina's zonder taalattribuut
+ERROR_NO_LANG_DESC: Het taalattribuut is bijzonder nuttig voor schermlezers en het wordt aanbevolen om het te gebruiken. Sommige zoekmachines gebruiken het om de juiste pagina te tonen op basis van de taal van de gebruiker, maar het beïnvloedt je ranking niet.
+
+ERROR_HTTP_LINKS: HTTPS-URL's met links naar HTTP-URL's
+ERROR_HTTP_LINKS_DESC: Links van beveiligde HTTPS-pagina's naar onbeveiligde HTTP-pagina's. Een volledig beveiligde website scoort beter dan websites zonder HTTPS en maakt gebruikers blijer.
+
+ERROR_HREFLANG_RETURN: Pagina's zonder hreflang-retourverwijzing
+ERROR_HREFLANG_RETURN_DESC: Wanneer je naar een pagina verwijst met hreflang, moet die pagina ook met een hreflang-tag terugverwijzen. Zonder deze wederzijdse verwijzing kunnen zoekmachines de hreflang-annotaties negeren, waardoor verkeerde taalversies in de zoekresultaten worden getoond.
+
+ERROR_TOO_MANY_LINKS: Pagina's met te veel links
+ERROR_TOO_MANY_LINKS_DESC: De SEO-linkwaarde wordt verdeeld over alle links op de pagina; hoe meer links er zijn, hoe minder waarde aan elke link wordt doorgegeven. Zorg dat alle links relevant zijn, verwijder de irrelevante of gebruik het nofollow-attribuut.
+
+ERROR_INTERNAL_NOFOLLOW: Interne nofollow-links
+ERROR_INTERNAL_NOFOLLOW_DESC: Interne links zouden in het algemeen geen nofollow-attribuut moeten gebruiken, tenzij ze verwijzen naar pagina's die je niet door zoekmachines wilt laten indexeren. Controleer de interne links en zorg dat belangrijke pagina's zonder nofollow-attribuut worden gelinkt.
+
+ERROR_EXTERNAL_WITHOUT_NOFOLLOW: Pagina's met externe follow-links
+ERROR_EXTERNAL_WITHOUT_NOFOLLOW_DESC: Follow-links geven SEO-autoriteit door aan externe sites. Houd hier oog op om linkspam in reacties en door gebruikers gegenereerde content te voorkomen.
+
+ERROR_CANONICALIZED_NON_CANONICAL: Gecanoniseerd naar niet-canonieke pagina
+ERROR_CANONICALIZED_NON_CANONICAL_DESC: Pagina's die zijn gecanoniseerd naar een niet-canonieke URL. Gecanoniseerde pagina's moeten verwijzen naar een canonieke pagina; vervang de canonieke link-URL op deze pagina's zodat ze naar een canonieke pagina wijzen.
+
+ERROR_NOT_VALID_HEADINGS: Pagina's zonder geldige volgorde van koppen
+ERROR_NOT_VALID_HEADINGS_DESC: De heading-tags op deze pagina's volgen niet de juiste volgorde. Koppen moeten beginnen met een H1 en een duidelijke hiërarchie volgen (H2, H3, enz.). Een goede structuur helpt zoekmachines je content te begrijpen en verbetert de toegankelijkheid voor schermlezers.
+
+ERROR_HREFLANG_TO_NON_CANONICAL: Hreflang naar niet-canonieke pagina
+ERROR_HREFLANG_TO_NON_CANONICAL_DESC: Hreflang-tags vertellen zoekmachines waar content in specifieke talen te vinden is; hreflang-tags die naar niet-canonieke pagina's verwijzen, verwarren zoekmachines.
+
+ERROR_NOFOLLOW_INDEXABLE: Interne nofollow-links naar indexeerbare pagina's
+ERROR_NOFOLLOW_INDEXABLE_DESC: Interne links met het nofollow-attribuut vertellen zoekmachines om die link niet te crawlen. Om dit goed te laten werken moet de bestemmings-URL het noindex-attribuut gebruiken, anders kunnen zoekmachines de gelinkte URL alsnog indexeren.
+
+ERROR_NO_INDEXABLE: Niet-indexeerbare pagina's
+ERROR_NO_INDEXABLE_DESC: Pagina's met het noindex-attribuut worden niet door zoekmachines geïndexeerd; dit wordt meestal toegevoegd aan minder belangrijke pagina's die we niet in de zoekresultaten willen laten verschijnen. Het is verstandig om ze te controleren om er zeker van te zijn dat belangrijke pagina's dit attribuut niet gebruiken.
+
+ERROR_HREFLANG_NO_INDEXABLE: Hreflang naar een niet-indexeerbare pagina
+ERROR_HREFLANG_NO_INDEXABLE_DESC: Hreflangs moeten naar indexeerbare pagina's verwijzen; verwijzen naar pagina's met het noindex-attribuut zal zoekmachines verwarren.
+
+ERROR_BLOCKED: URL's geblokkeerd door robots.txt
+ERROR_BLOCKED_DESC: Pagina's die worden geblokkeerd door robots.txt worden niet gecrawld door zoekmachines. Houd deze lijst in de gaten om er zeker van te zijn dat geen belangrijke pagina's worden geblokkeerd.
+
+ERROR_ORPHAN: Verweesde pagina's
+ERROR_ORPHAN_DESC: Pagina's waarnaar nergens op je site wordt gelinkt; geen enkele bezoeker kan ze bereiken en dit kan tot verspilling van crawlbudget leiden.
+
+NO_INDEX_IN_SITEMAP: Niet-indexeerbare pagina's opgenomen in de sitemap
+NO_INDEX_IN_SITEMAP_DESC: Niet-indexeerbare pagina's horen niet in een sitemap thuis, omdat dit gemengde signalen geeft aan zoekmachines. Het kan ook het crawlproces vertragen en tot onjuiste indexering leiden.
+
+BLOCKED_IN_SITEMAP: Geblokkeerde pagina's opgenomen in de sitemap
+BLOCKED_IN_SITEMAP_DESC: Pagina's die door het robots.txt-bestand worden geblokkeerd, horen niet in de sitemap thuis omdat dit gemengde signalen aan zoekmachines geeft. Het kan ook het crawlproces vertragen en tot onjuiste indexering leiden.
+
+NON_CANONICAL_IN_SITEMAP: Niet-canonieke pagina's opgenomen in de sitemap
+NON_CANONICAL_IN_SITEMAP_DESC: Niet-canonieke pagina's horen niet in een sitemap thuis omdat ze zoekmachines kunnen misleiden, tijd en middelen verspillen en tot onjuiste indexering leiden.
+
+INCOMING_FOLLOW_NOFOLLOW: Pagina's met inkomende follow- en nofollow-links
+INCOMING_FOLLOW_NOFOLLOW_DESC: Pagina's met interne inkomende follow- en nofollow-links kunnen autoriteits- en relevantiesignalen verwateren, zoekmachines verwarren en de kans op een hoge ranking in zoekresultaten verkleinen.
+
+INVALID_LANG: Pagina's met een ongeldig lang-attribuut
+INVALID_LANG_DESC: Pagina's met een ongeldig lang-attribuut kunnen problemen opleveren voor zowel zoekmachines als gebruikers. Zoekmachines kunnen moeite hebben met het identificeren van de taal van de content, terwijl gebruikers moeite kunnen hebben om de content te begrijpen of hulptechnologieën te gebruiken.
+
+HTTP_SCHEME: Pagina's die het HTTP-schema gebruiken
+HTTP_SCHEME_DESC: Pagina's die HTTP gebruiken in plaats van HTTPS. HTTPS is belangrijk omdat het een veiligere en betrouwbaardere website biedt, wat kan leiden tot meer gebruikersbetrokkenheid en betere posities in zoekmachines.
+
+DEAD_END: Doodlopende pagina's
+DEAD_END_DESC: Een doodlopende pagina is een webpagina zonder enige link naar andere pagina's. Hierdoor kunnen gebruikers en zoekmachines niet verder navigeren dan de huidige pagina, wat het verkennen van de site bemoeilijkt en zowel de gebruikerservaring als de crawlbaarheid van de site beïnvloedt.
+
+ERROR_CANONICALIZED_NON_INDEXABLE: Gecanoniseerd naar niet-indexeerbare pagina
+ERROR_CANONICALIZED_NON_INDEXABLE_DESC: Pagina's gecanoniseerd naar andere niet-indexeerbare pagina's. Hiermee vertel je zoekmachines feitelijk dat de niet-indexeerbare pagina de voorkeursversie van de content is, wat tot verwarring kan leiden en ervoor kan zorgen dat de content minder snel door gebruikers wordt gevonden.
+
+ERROR_HREFLANG_REDIRECT: Hreflang naar redirect
+ERROR_HREFLANG_REDIRECT_DESC: Pagina's met hreflang-links naar pagina's die worden doorverwezen met statuscodes in het 30x-bereik. Dit kan voor verwarring zorgen bij zoekmachines die moeite kunnen hebben om de relatie tussen de oorspronkelijke en de doorverwezen pagina te begrijpen.
+
+ERROR_CANONICAL_REDIRECT: Gecanoniseerd naar redirect
+ERROR_CANONICAL_REDIRECT_DESC: Pagina's die zijn gecanoniseerd naar doorverwezen URL's in plaats van naar de daadwerkelijke voorkeursversie van de pagina. Dit kan zoekmachines verwarren bij het navigeren en begrijpen van je website.
+
+ERROR_HREFLANG_ERROR: Hreflang naar fout
+ERROR_HREFLANG_ERROR_DESC: Pagina's met hreflang-tags die verwijzen naar URL's die fouten geven met statuscodes in het 40x- of 50x-bereik. Hierdoor kunnen zoekmachines verschillende versies van je pagina niet goed indexeren, wat je positie in zoekmachines kan beïnvloeden.
+
+ERROR_CANONICAL_ERROR: Gecanoniseerd naar fout
+ERROR_CANONICAL_ERROR_DESC: Pagina's die zijn gecanoniseerd naar URL's die fouten geven met statuscodes in het 40x- of 50x-bereik. Dit kan zoekmachines verwarren, waardoor ze de voorkeursversie van de pagina niet kunnen crawlen.
+
+ERROR_MULTIPLE_CANONICAL_TAGS: Meerdere canonieke tags
+ERROR_MULTIPLE_CANONICAL_TAGS_DESC: Pagina's die meer dan één canonieke tag in de header bevatten. Meerdere canonieke tags verwarren zoekmachines over de voorkeursversie van de pagina, met mogelijke indexerings- en rankingproblemen tot gevolg.
+
+ERROR_RELATIVE_CANONICAL_URL: Canoniek met relatieve URL
+ERROR_RELATIVE_CANONICAL_URL_DESC: Pagina's die relatieve URL's gebruiken in de canonieke tag. Hoewel relatieve paden door sommige zoekmachines worden ondersteund, kunnen ze op de lange termijn problemen geven, zoals onjuiste indexering en ranking. Gebruik bij voorkeur absolute URL's.
+
+ERROR_HREFLANG_XDEFAULT: Standaardtaaltag ontbreekt
+ERROR_HREFLANG_XDEFAULT_DESC: Pagina's zonder de "x-default" hreflang-waarde. Door de standaardtaal of -regio van een pagina aan te geven, zorg je voor correcte indexering voor gebruikers die met geen enkele specifieke hreflang-waarde overeenkomen.
+
+ERROR_HREFLANG_SELF_REFERENCE: Zelfverwijzing in hreflang ontbreekt
+ERROR_HREFLANG_SELF_REFERENCE_DESC: Een zelfverwijzing in hreflang-tags is essentieel om de taal of regio van de huidige pagina aan te geven en voorkomt mogelijke verwarring bij zoekmachines.
+
+ERROR_HREFLANG_MISMATCHING_LANG: Niet-overeenkomende taal
+ERROR_HREFLANG_MISMATCHING_LANG_DESC: Verschillende taalcodes in het HTML lang-attribuut en de zelfverwijzende hreflang-waarde kunnen zoekmachines verwarren en SEO negatief beïnvloeden door een verkeerde interpretatie van de taal of regio van de pagina.
+
+ERROR_HREFLANG_RELATIVE_URL: Hreflang-waarden met relatieve URL's
+ERROR_HREFLANG_RELATIVE_URL_DESC: Pagina's die relatieve URL's gebruiken in hreflang-waarden. Alternatieve URL's in hreflang-tags moeten absoluut zijn. Vervang ze om crawlbaarheidsproblemen en onjuiste taalherkenning van de pagina te voorkomen.
+
+ERROR_CANONICAL_MISMATCH: Canonieke afwijking
+ERROR_CANONICAL_MISMATCH_DESC: Pagina's met verschillende canonieke URL's in de HTML-code en HTTP-headers. Het instellen van verschillende canonieke URL's in de HTML-code en HTTP-headers veroorzaakt inconsistentie en kan zoekmachines verwarren, wat kan leiden tot lagere posities en zichtbaarheid in zoekmachines.
+
+ERROR_MISSING_HSTS: HSTS-header ontbreekt
+ERROR_MISSING_HSTS_DESC: Pagina's zonder HSTS-header. Het ontbreken van de HTTP Strict Transport Security-header maakt sites kwetsbaarder voor beveiligingsrisico's, wat SEO kan beïnvloeden op het gebied van gebruikersveiligheid en betrouwbaarheid.
+
+ERROR_MISSING_CSP: Content Security Policy ontbreekt
+ERROR_MISSING_CSP_DESC: Pagina's zonder de CSP (Content Security Policy) HTML-metatag of HTTP-header zijn kwetsbaarder voor beveiligingsrisico's, wat kan leiden tot kwaadaardige content of gecompromitteerde gebruikerservaringen, wat zoekmachines kunnen bestraffen.
+
+ERROR_CONTENT_TYPE_OPTIONS: Content-type-options ontbreekt
+ERROR_CONTENT_TYPE_OPTIONS_DESC: Pagina's zonder X-Content-Type-Options-header stellen de website bloot aan beveiligingsrisico's rond content-types, wat kan leiden tot SEO-straffen en onveilige gebruikerservaringen.
+
+ERROR_LARGE_IMAGE: Grote afbeeldingen
+ERROR_LARGE_IMAGE_DESC: Grote afbeeldingen kunnen het laden van een webpagina vertragen, wat de gebruikerservaring en SEO-rankings negatief beïnvloedt door de toegenomen laadtijden. Gebruik grote afbeeldingen alleen als het echt nodig is en optimaliseer ze tot een redelijke grootte.
+
+ERROR_LONG_ALT_TEXT: Afbeeldingen met lange alt-tekst
+ERROR_LONG_ALT_TEXT_DESC: Pagina's met afbeeldingen die een lange tekst in het alt-attribuut hebben. Een lange tekst in het alt-attribuut maakt het moeilijker om de inhoud en het doel van de afbeelding te begrijpen. Probeer de alt-tekst kort en bondig te houden.
+
+ERROR_MULTIPLE_TITLES: Meerdere title-tags
+ERROR_MULTIPLE_TITLES_DESC: Pagina's met meer dan één title-tag in de header. Meerdere title-tags in de HTML-header schaden SEO doordat ze zoekmachines verwarren en het lastiger maken om de inhoud van de pagina te begrijpen.
+
+ERROR_MULTIPLE_DESCRIPTIONS: Meerdere description-metatags
+ERROR_MULTIPLE_DESCRIPTIONS_DESC: Pagina's met meer dan één description-metatag in de header. Meerdere description-metatags in de HTML-header schaden SEO doordat ze zoekmachines verwarren en het lastiger maken om de inhoud van de pagina te begrijpen.
+
+ERROR_PAGE_DEPTH: Grote diepte
+ERROR_PAGE_DEPTH_DESC: Pagina's met een grote diepte kunnen SEO en gebruikerservaring negatief beïnvloeden omdat ze zowel voor zoekmachines als voor gebruikers moeilijker bereikbaar zijn, met als gevolg een lagere zichtbaarheid in zoekresultaten en een minder intuïtieve navigatie.
+
+ERROR_MULTIPLE_LANG_REFERENCE: Meerdere taalverwijzingen
+ERROR_MULTIPLE_LANG_REFERENCE_DESC: Pagina's waarin meerdere talen worden aangegeven in hreflang-tags kunnen zoekmachines verwarren, wat kan leiden tot onjuiste taalindexering en een negatieve impact op SEO en gebruikerservaring.
+
+ERROR_DUPLICATED_CONTENT: Dubbele content
+ERROR_DUPLICATED_CONTENT_DESC: Pagina's met exact dezelfde content kunnen zoekmachines verwarren en het lastig maken om de meest relevante pagina te bepalen, wat leidt tot indexeringsproblemen, verwaterde rankings en verspilling van crawlbudget.
+
+ERROR_EXTERNAL_LINK_REDIRECT: Pagina's met externe links naar redirect-URL's
+ERROR_EXTERNAL_LINK_REDIRECT_DESC: Externe links naar doorverwezen pagina's beïnvloeden de zoekresultaten van je site niet, maar kunnen wel de gebruikerservaring beïnvloeden. Vervang de links door hun uiteindelijke bestemmingen om dit op te lossen.
+
+ERROR_EXTERNAL_LINK_BROKEN: Pagina's met gebroken externe links
+ERROR_EXTERNAL_LINK_BROKEN_DESC: Gebroken externe links beïnvloeden de zoekresultaten van je site niet, maar kunnen gebruikers frustreren door ze naar niet-bestaande pagina's te leiden. Los dit op door de link te verwijderen of bij te werken naar de juiste URL.
+
+ERROR_TIMEOUT: Time-out
+ERROR_TIMEOUT_DESC: Pagina's die een time-out gaven toen onze crawler probeerde ze te bereiken. Wanneer dit gebeurt, kunnen crawlers van zoekmachines de content niet bereiken en indexeren, wat duidt op mogelijke serverproblemen of tijdelijke obstakels die de zichtbaarheid in zoekresultaten belemmeren.
+
+ERROR_UNDERSCORE_URL: URL's met underscore-tekens
+ERROR_UNDERSCORE_URL_DESC: Het wordt meestal afgeraden om underscore-tekens in URL's te gebruiken, omdat sommige zoekmachines ze negeren en dat deel als één woord behandelen. Gebruik in plaats daarvan een streepje als woordscheidingsteken.
+
+ERROR_SLOW_TTFB: Trage Time to First Byte
+ERROR_SLOW_TTFB_DESC: Een trage Time to First Byte kan de gebruikerservaring negatief beïnvloeden en SEO schaden door langere laadtijden, omdat sommige zoekmachines paginasnelheid als rankingfactor meewegen.
+
+ERROR_HTTP_FORM: Formulieren op HTTP-pagina's
+ERROR_HTTP_FORM_DESC: HTTP-pagina's met formulieren. Een formulier op een HTTP-URL brengt de veiligheid in gevaar, vermindert het vertrouwen van gebruikers en verlaagt SEO-rankings. Zorg dat je formulieren op HTTPS-pagina's staan.
+
+ERROR_INSECURE_FORM: Onveilige formulieren
+ERROR_INSECURE_FORM_DESC: Pagina's met formulieren met HTTP-action-URL's. Een formulier met een HTTP-action-URL stelt gegevens bloot aan onderschepping, vermindert het vertrouwen, leidt tot browserwaarschuwingen en heeft een negatieve impact op SEO-rankings.
+
+ERROR_SPACE_URL: URL's die een spatie bevatten
+ERROR_SPACE_URL_DESC: Een spatie in de URL kan indexeringsproblemen en gebroken links veroorzaken, wat negatieve gevolgen heeft voor SEO en gebruikerservaring. Gebruik streepjes als woordscheidingsteken in plaats van spaties.
+
+ERROR_MULTIPLE_SLASHES: URL's met meerdere slashes in het pad
+ERROR_MULTIPLE_SLASHES_DESC: URL's met meerdere opeenvolgende slashes in het pad. Dit kan zoekmachines en gebruikers verwarren en mogelijk leiden tot indexeringsproblemen en een minder verzorgde, professionele uitstraling.
+
+ERROR_NOIMAGEINDEX: Pagina's met de noimageindex-regel
+ERROR_NOIMAGEINDEX_DESC: De noimageindex-regel in de robots-metatag voorkomt dat afbeeldingen door zoekmachines worden geïndexeerd. Controleer deze pagina's om er zeker van te zijn dat de afbeeldingen op deze pagina's inderdaad niet geïndexeerd hoeven te worden.
+
+ERROR_PICTURE_MISSONG_IMG: Pagina's met picture-elementen zonder img-element
+ERROR_PICTURE_MISSONG_IMG_DESC: Pagina's die een picture-HTML-element gebruiken waarbij het img-element ontbreekt. Hierdoor kunnen afbeeldingen niet correct worden weergegeven in de browser en kan het tot indexeringsproblemen voor afbeeldingen in zoekmachines leiden.
+
+ERROR_METAS_IN_BODY: Pagina's met metatags in de body van het document
+ERROR_METAS_IN_BODY_DESC: Pagina's met metatags in de body van het document. De metatags moeten in de head van het document worden geplaatst, anders kunnen ze door browsers en zoekmachines worden genegeerd, met indexeerbaarheidsproblemen tot gevolg.
+
+ERROR_NOSNIPPET: Pagina's met de nosnippet-richtlijn
+ERROR_NOSNIPPET_DESC: De nosnippet- of max-snippet:0-richtlijnen vertellen zoekmachines om geen tekstsnippet of videovoorbeeld in de zoekresultaten te tonen. Controleer deze pagina's om er zeker van te zijn dat dit het gewenste gedrag is.
+
+ERROR_IMG_SIZE_ATTR: Pagina's met afbeeldingen zonder grootteattributen
+ERROR_IMG_SIZE_ATTR_DESC: Het niet instellen van de grootteattributen voor afbeeldingen kan layout-shifts veroorzaken tijdens het laden van de pagina, wat een negatieve invloed kan hebben op de gebruikerservaring én SEO. Zorg dat je afbeeldingen de juiste grootteattributen hebben.
+
+ERROR_INCORRECT_MEDIA_TYPE: URL's met een onjuist mediatype
+ERROR_INCORRECT_MEDIA_TYPE_DESC: URL's met onjuiste MIME-types kunnen SEO schaden doordat browsers de inhoud verkeerd interpreteren of niet kunnen weergeven, wat de gebruikerservaring en de indexering door zoekmachines beïnvloedt.
+
+ERROR_DUPLICATED_ID: Pagina's met elementen met dubbele ID's
+ERROR_DUPLICATED_ID_DESC: Elementen met dubbele ID's verwarren hulptechnologieën en JavaScript, wat tot navigatieproblemen en onvoorspelbaar gedrag kan leiden. Dit kan invloed hebben op de gebruikerservaring en SEO. Zorg dat ID's uniek zijn.
+
+ERROR_MISSING_VIEWPORT: Pagina's zonder viewport-metatag
+ERROR_MISSING_VIEWPORT_DESC: Een webpagina zonder de viewport-metatag wordt niet correct weergegeven op mobiele apparaten, wat leidt tot een slechte gebruikerservaring en lagere posities in zoekresultaten.
+
+ERROR_DOM_SIZE: HTML-documenten met een te grote DOM-omvang
+ERROR_DOM_SIZE_DESC: Pagina's met een grote DOM-omvang kunnen het laden van pagina's vertragen en het voor zoekmachines moeilijker maken om de content efficiënt te crawlen en te indexeren. Vereenvoudig je HTML-structuur door overbodige elementen te verwijderen en het gebruik van geneste tags te beperken.
+
+ERROR_PAGINATION_LINKS: Paginerings-URL niet gelinkt
+ERROR_PAGINATION_LINKS_DESC: link rel="next"- en link rel="prev"-tags zonder bijbehorende links in de body verwarren zoekmachines, wat leidt tot slechte indexering en een frustrerende navigatie-ervaring.
+
+ERROR_LOCALHOST_LINKS: Webpagina's met links naar localhost
+ERROR_LOCALHOST_LINKS_DESC: Links naar localhost of 127.0.0.1 zijn niet bereikbaar voor gebruikers en zoekmachines, wat fouten en slechte SEO veroorzaakt. Los dit op door deze links te vervangen door de juiste publieke URL's die naar je live website verwijzen.

--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -38,6 +38,7 @@
 						<option value="en"{{ if eq $userLang "en" }} selected{{ end }}>English</option>
 						<option value="es"{{ if eq $userLang "es" }} selected{{ end }}>Español</option>
 						<option value="fa"{{ if eq $userLang "fa" }} selected{{ end }}>فارسی</option>
+						<option value="nl"{{ if eq $userLang "nl" }} selected{{ end }}>Nederlands</option>
 					</select>
 
 				</div>


### PR DESCRIPTION
## Summary
- Adds `translations/translation.nl.yaml` with Dutch translations for all 451 keys from `translation.en.yaml`, preserving placeholders (`%1%`, `%2%`) and the existing comments/section headers.
- Adds Dutch (`Nederlands`) as a selectable option in the language dropdown on the account page (`web/templates/account.html`).
- The `nl` locale is already wired into `internal/services/translator.go`'s monday locale map (`monday.LocaleNlNL`), so no Go code changes were needed beyond the template option.

## Test plan
- [x] `go test ./internal/services/...` passes (translator tests).
- [x] `go build ./...` builds clean.
- [x] Verified key parity: 451/451 keys present, no missing or extra keys vs. `translation.en.yaml`.
- [x] Verified placeholder integrity: every `%1%` / `%2%` in the source is preserved in the translation.
- [x] Built and ran the Docker stack (`docker compose up --build`); app boots without translation-loading warnings and the new `Nederlands` option appears in the account form.