### PR TITLE
Fix crawl hanging when a sitemap request fails

### DIFF
--- a/internal/crawler/sitemap_checker.go
+++ b/internal/crawler/sitemap_checker.go
@@ -55,6 +55,11 @@ func (sc *SitemapChecker) ParseSitemaps(URLs []string, callback func(u string)) 
 			// Each sitemap is parsed in its own Go routine
 			// If the sitemap limit is hit the parser function returns an error to stop the process
 			go func(s string) {
+				// wg.Done is deferred so the WaitGroup is always decremented,
+				// including when the sitemap request fails and the goroutine
+				// returns early. Otherwise wg.Wait below blocks forever.
+				defer wg.Done()
+
 				resp, err := sc.client.Get(s)
 				if err != nil {
 					return
@@ -74,8 +79,6 @@ func (sc *SitemapChecker) ParseSitemaps(URLs []string, callback func(u string)) 
 
 					return nil
 				})
-
-				wg.Done()
 			}(s)
 		}
 	}

--- a/internal/crawler/sitemap_checker_test.go
+++ b/internal/crawler/sitemap_checker_test.go
@@ -1,0 +1,167 @@
+package crawler_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stjudewashere/seonaut/internal/crawler"
+)
+
+const sitemapTestTimeout = 5 * time.Second
+
+// sitemapMockClient serves a valid urlset for any URL containing "good" and
+// returns an error for any URL containing "bad", simulating a sitemap that is
+// unreachable at request time.
+type sitemapMockClient struct {
+	mu       sync.Mutex
+	requests []string
+}
+
+func (m *sitemapMockClient) Head(u string) (*crawler.ClientResponse, error) {
+	return &crawler.ClientResponse{Response: &http.Response{StatusCode: http.StatusOK}}, nil
+}
+
+func (m *sitemapMockClient) Get(u string) (*crawler.ClientResponse, error) {
+	m.mu.Lock()
+	m.requests = append(m.requests, u)
+	m.mu.Unlock()
+
+	if strings.Contains(u, "bad") {
+		return nil, errors.New("mock transport error")
+	}
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+	<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+		<url><loc>https://example.com/page1</loc></url>
+		<url><loc>https://example.com/page2</loc></url>
+	</urlset>`
+
+	return &crawler.ClientResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+		},
+	}, nil
+}
+
+func (m *sitemapMockClient) GetUAName() string {
+	return "SEOnautBot"
+}
+
+// newSitemapIndexServer returns a test server serving a sitemap index that
+// references the given sitemap locations. ParseSitemaps resolves the index over
+// the network, so a local server keeps the test hermetic.
+func newSitemapIndexServer(t *testing.T, locs ...string) *httptest.Server {
+	t.Helper()
+
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	sb.WriteString(`<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	for _, l := range locs {
+		sb.WriteString("<sitemap><loc>" + l + "</loc></sitemap>")
+	}
+	sb.WriteString(`</sitemapindex>`)
+	index := sb.String()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, index)
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// runParseSitemaps runs ParseSitemaps with a timeout, collecting the URLs passed
+// to the callback. It fails the test rather than hanging if ParseSitemaps never
+// returns, so a regression shows up as a failure instead of a stuck CI job.
+func runParseSitemaps(t *testing.T, sc *crawler.SitemapChecker, urls []string) []string {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc.ParseSitemaps(urls, func(u string) {
+			mu.Lock()
+			defer mu.Unlock()
+			seen = append(seen, u)
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(sitemapTestTimeout):
+		t.Fatalf("ParseSitemaps did not return within %s; the WaitGroup was never released", sitemapTestTimeout)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	return append([]string(nil), seen...)
+}
+
+// TestParseSitemapsReturnsWhenRequestFails makes sure ParseSitemaps returns when
+// every sitemap request fails. Each sitemap goroutine has to decrement the
+// WaitGroup even on the error path, otherwise Wait blocks forever and the crawl
+// never starts.
+func TestParseSitemapsReturnsWhenRequestFails(t *testing.T) {
+	server := newSitemapIndexServer(t, "https://example.com/bad1.xml", "https://example.com/bad2.xml")
+
+	sc := crawler.NewSitemapChecker(&sitemapMockClient{}, 100)
+
+	if urls := runParseSitemaps(t, sc, []string{server.URL}); len(urls) != 0 {
+		t.Errorf("expected no urls from failing sitemaps, got %d", len(urls))
+	}
+}
+
+// TestParseSitemapsWithFailingAndWorkingSitemaps makes sure one unreachable
+// sitemap does not prevent the remaining sitemaps from being parsed. A sitemap
+// index commonly fans out to several children, and a single failed request must
+// not discard the others.
+func TestParseSitemapsWithFailingAndWorkingSitemaps(t *testing.T) {
+	server := newSitemapIndexServer(t, "https://example.com/bad.xml", "https://example.com/good.xml")
+
+	sc := crawler.NewSitemapChecker(&sitemapMockClient{}, 100)
+
+	urls := runParseSitemaps(t, sc, []string{server.URL})
+	if len(urls) != 2 {
+		t.Fatalf("expected 2 urls from the working sitemap, got %d: %v", len(urls), urls)
+	}
+
+	for _, want := range []string{"https://example.com/page1", "https://example.com/page2"} {
+		found := false
+		for _, got := range urls {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected url %s in %v", want, urls)
+		}
+	}
+}
+
+// TestParseSitemapsRespectsLimit makes sure the callback is not called more than
+// the configured limit allows.
+func TestParseSitemapsRespectsLimit(t *testing.T) {
+	server := newSitemapIndexServer(t, "https://example.com/good.xml")
+
+	sc := crawler.NewSitemapChecker(&sitemapMockClient{}, 1)
+
+	if urls := runParseSitemaps(t, sc, []string{server.URL}); len(urls) > 1 {
+		t.Errorf("expected at most 1 url with a limit of 1, got %d: %v", len(urls), urls)
+	}
+}


### PR DESCRIPTION
Fixes #51.

## Problem

`SitemapChecker.ParseSitemaps` calls `wg.Add(1)` for every sitemap, but `wg.Done()` was only reached on the success path. When `sc.client.Get` returned an error the goroutine returned early, the WaitGroup counter never reached zero, and `wg.Wait()` blocked forever.

`ParseSitemaps` is called from `Crawler.Start`, so a single failed sitemap request hung the entire crawl before a single page was fetched — the UI sits on "Crawling..." indefinitely with no page reports and no outbound requests.

A **transient** error is enough to hang the crawl permanently. Sites whose sitemap index fans out to many children are more exposed, because the children are requested concurrently: the more parallel requests, the higher the chance that one fails.

## Fix

Defer `wg.Done()` so the WaitGroup is released on every path, including the early return. Unreachable sitemaps are skipped and the remaining ones are still parsed and crawled.

```diff
 go func(s string) {
+	defer wg.Done()
+
 	resp, err := sc.client.Get(s)
 	if err != nil {
 		return
 	}
 	...
-	wg.Done()
 }(s)
```

## Tests

`sitemap_checker.go` had no test file. This adds `internal/crawler/sitemap_checker_test.go` covering:

- `TestParseSitemapsReturnsWhenRequestFails` — every sitemap request fails; `ParseSitemaps` must still return.
- `TestParseSitemapsWithFailingAndWorkingSitemaps` — one unreachable sitemap must not discard the working ones. This is the real-world case: an index with several children where one request fails.
- `TestParseSitemapsRespectsLimit` — the crawl limit is still honoured.

Two details worth noting:

- The tests run `ParseSitemaps` in a goroutine guarded by a timeout, so a regression **fails** the test rather than hanging the whole test run. Without that, a reintroduced bug would stall CI instead of reporting.
- They use a local `httptest` server for the sitemap index, because `ParseSitemaps` resolves the index over the network via `checkIndex`. This keeps the tests hermetic and fast.

Verified against the exact CI commands:

```
$ go test -race -parallel 1 -short ./internal/...
ok  	github.com/stjudewashere/seonaut/internal/config	1.629s
ok  	github.com/stjudewashere/seonaut/internal/crawler	2.029s
ok  	github.com/stjudewashere/seonaut/internal/issues/page	2.590s
ok  	github.com/stjudewashere/seonaut/internal/repository	2.699s
ok  	github.com/stjudewashere/seonaut/internal/services	15.287s
ok  	github.com/stjudewashere/seonaut/internal/urlutils	1.910s

$ go build -race ./cmd/server/main.go
```

Confirmed the tests actually catch the bug — reverting `sitemap_checker.go` to `main` and rerunning:

```
--- FAIL: TestParseSitemapsReturnsWhenRequestFails (5.00s)
    sitemap_checker_test.go:124: ParseSitemaps did not return within 5s; the WaitGroup was never released
--- FAIL: TestParseSitemapsWithFailingAndWorkingSitemaps (5.00s)
    sitemap_checker_test.go:138: ParseSitemaps did not return within 5s; the WaitGroup was never released
FAIL
```

`gofmt -l` and `go vet ./internal/crawler/` are both clean.

## Notes

Beyond the scope of this PR, but noticed while debugging: a crawl that stalls has no timeout or watchdog, so any future hang in `Crawler.Start` presents the same way — an indefinite "Crawling..." with no diagnostics. A crawl-level timeout, or logging failed sitemap requests instead of silently swallowing the error, would make this class of problem much easier to spot. Happy to open a separate issue if that is of interest.
